### PR TITLE
By default, don't map the `buildkite-agent` binary into the sandbox (but allow the user to toggle this option)

### DIFF
--- a/lib/generate_sandboxed_bash.jl
+++ b/lib/generate_sandboxed_bash.jl
@@ -67,12 +67,20 @@ read_only_mappings = Dict{String,String}(
     "/" => Pkg.Artifacts.artifact_path(rootfs_treehash),
 )
 
-# The path to `buildkite-agent`, if it exists
-# Note that it's kosher to mount a single executable in like this since it's a
-# `go` executable that is completely self-contained (statically linked, etc...)
-buildkite_agent_path = Sys.which("buildkite-agent")
-if buildkite_agent_path !== nothing
-    read_only_mappings["/usr/bin/buildkite-agent"] = buildkite_agent_path
+if parse(Bool, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_MAP_BUILDKITE_AGENT", "false"))
+    # The path to `buildkite-agent`, if it exists
+    # Note that it's kosher to mount a single executable in like this since it's a
+    # `go` executable that is completely self-contained (statically linked, etc...)
+    buildkite_agent_path = Sys.which("buildkite-agent")
+    if buildkite_agent_path !== nothing
+        read_only_mappings["/usr/bin/buildkite-agent"] = buildkite_agent_path
+    else
+        msg = string(
+            "The `buildkite_agent` configuration property is set to true, ",
+            "but the `buildkite-agent` binary was not found in the path.",
+        )
+        @warn msg
+    end
 end
 
 # If we have a `resolv.conf` to share, do so

--- a/lib/generate_sandboxed_bash.jl
+++ b/lib/generate_sandboxed_bash.jl
@@ -76,7 +76,7 @@ if parse(Bool, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_MAP_BUILDKITE_AGENT", "false")
         read_only_mappings["/usr/bin/buildkite-agent"] = buildkite_agent_path
     else
         msg = string(
-            "The `buildkite_agent` configuration property is set to true, ",
+            "The `map_buildkite_agent` configuration property is set to true, ",
             "but the `buildkite-agent` binary was not found in the path.",
         )
         @warn msg

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,7 +14,6 @@ configuration:
     # - `${BUILDKITE_BUILD_PATH}`: the repository checkout path
     # - `${BUILDKITE_PLUGINS_PATH}`: the plugins directory
     # - `${TMPDIR}`: the temporary directory, since many plugins require communicating through it
-    # - `buildkite-agent`: wherever `buildkite-agent` is located, it gets mapped in as `/usr/bin/buildkite-agent`.
     # - `/etc/resolv.conf`: We assume you want to be able to resolve DNS queries.
     workspaces:
       type: array
@@ -24,6 +23,10 @@ configuration:
       type: string
     gid:
       type: string
+
+    # If this is set to true, the `buildkite-agent` binary will be mapped in as `/usr/bin/buildkite-agent`.
+    map_buildkite_agent:
+      type: boolean
 
     # If this is set, causes all sorts of debugging information to be printed out
     verbose:


### PR DESCRIPTION
Fixes #3