### PR TITLE
Download artifact files during the `pre-command` hook, and upload artifact files during the `post-command` hook

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,3 +10,6 @@ fi
 # Un-do our crazy `bash` override
 echo "Removing sandbox /bin/bash overrride"
 mv /bin/truebash /bin/bash
+
+# Upload artifacts
+julia --project="${SANDBOX_REPO}/lib" "${SANDBOX_REPO}/lib/artifacts_upload.jl"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -34,6 +34,9 @@ fi
 echo "--- Instantiating sandbox environment"
 julia --project="${SANDBOX_REPO}/lib" -e "using Pkg; Pkg.instantiate()"
 
+# Download artifacts
+julia --project="${SANDBOX_REPO}/lib" "${SANDBOX_REPO}/lib/artifacts_download.jl"
+
 # Perform absurd bash overwriting, so that all future commands are sandboxed
 echo "--- Installing bash override"
 cp -va /bin/bash /bin/truebash

--- a/lib/artifacts_download.jl
+++ b/lib/artifacts_download.jl
@@ -1,0 +1,26 @@
+include(joinpath(@__DIR__, "utils.jl"))
+
+if Sys.which("buildkite-agent") === nothing
+    throw(ErrorException("The `buildkite-agent` was not found in the path."))
+end
+
+download_filenames = extract_env_array("BUILDKITE_PLUGIN_SANDBOX_ARTIFACTS_DOWNLOAD")
+
+buildkite_download_dir_host = get_download_dir_host()
+buildkite_upload_dir_host   = get_upload_dir_host()
+rm(buildkite_download_dir_host; force = true, recursive = true)
+rm(buildkite_upload_dir_host;   force = true, recursive = true)
+if ispath(buildkite_download_dir_host)
+    throw(ErrorException("Could not successfully erase: $(buildkite_download_dir_host)"))
+end
+if ispath(buildkite_upload_dir_host)
+    throw(ErrorException("Could not successfully erase: $(buildkite_upload_dir_host)"))
+end
+mkpath(buildkite_download_dir_host)
+mkpath(buildkite_upload_dir_host)
+
+cd(buildkite_download_dir_host) do
+    for name in strip.(download_filenames)
+        run(`buildkite-agent artifact download $(name) .`)
+    end
+end

--- a/lib/artifacts_upload.jl
+++ b/lib/artifacts_upload.jl
@@ -1,0 +1,33 @@
+include(joinpath(@__DIR__, "utils.jl"))
+
+if Sys.which("buildkite-agent") === nothing
+    throw(ErrorException("The `buildkite-agent` was not found in the path."))
+end
+
+upload_filenames = extract_env_array("BUILDKITE_PLUGIN_SANDBOX_ARTIFACTS_UPLOAD")
+
+buildkite_download_dir_host = get_buildkite_upload_dir_host()
+buildkite_upload_dir_host = get_buildkite_upload_dir_host()
+mkpath(buildkite_download_dir_host)
+mkpath(buildkite_upload_dir_host)
+
+cd(buildkite_upload_dir_host) do
+    root = pwd()
+    for name in strip.(upload_filenames)
+        full_path = joinpath(root, name)
+        if isfile(full_path)
+            run(`buildkite-agent artifact upload $(name)`)
+        else
+            @warn("File $(name) does not exist, so it will not be uploaded.")
+        end
+    end
+end
+
+rm(buildkite_download_dir_host; force = true, recursive = true)
+rm(buildkite_upload_dir_host;   force = true, recursive = true)
+if ispath(buildkite_download_dir_host)
+    throw(ErrorException("Could not successfully erase: $(buildkite_download_dir_host)"))
+end
+if ispath(buildkite_upload_dir_host)
+    throw(ErrorException("Could not successfully erase: $(buildkite_upload_dir_host)"))
+end

--- a/lib/generate_sandboxed_bash.jl
+++ b/lib/generate_sandboxed_bash.jl
@@ -1,17 +1,7 @@
 #!/usr/bin/env julia
 using Pkg, Sandbox
 
-# Helper to extract buildkite environment arrays
-function extract_env_array(prefix::String)
-    envname(idx::Int) = string(prefix, "_", idx)
-    idx = 0
-    array = String[]
-    while haskey(ENV, envname(idx))
-        push!(array, ENV[envname(idx)])
-        idx += 1
-    end
-    return array
-end
+include(joinpath(@__DIR__, "utils.jl"))
 
 rootfs_url = ENV["BUILDKITE_PLUGIN_SANDBOX_ROOTFS_URL"]
 rootfs_treehash = Base.SHA1(ENV["BUILDKITE_PLUGIN_SANDBOX_ROOTFS_TREEHASH"])
@@ -59,7 +49,10 @@ for (sandbox_path, host_path) in workspaces
     workspace_mappings[envexpand(sandbox_path)] = abspath(envexpand(host_path))
 end
 
-
+workspace_mappings[get_download_dir_guest()] = get_buildkite_download_dir_host()
+workspace_mappings[get_upload_dir_guest()]   = get_buildkite_upload_dir_host()
+@info "Inside the sandbox, the Buildkite download directory will be: $(get_download_dir_guest())"
+@info "Inside the sandbox, the Buildkite upload directory will be:   $(get_upload_dir_guest())"
 
 # Read-only mounts that we'll scatter throughout the build image
 read_only_mappings = Dict{String,String}(

--- a/lib/utils.jl
+++ b/lib/utils.jl
@@ -1,0 +1,30 @@
+# Helper to extract buildkite environment arrays
+function extract_env_array(prefix::String)
+    envname(idx::Int) = string(prefix, "_", idx)
+    idx = 0
+    array = String[]
+    while haskey(ENV, envname(idx))
+        push!(array, ENV[envname(idx)])
+        idx += 1
+    end
+    return array
+end
+
+get_download_dir_guest() = "/buildkite-download/"
+get_upload_dir_guest()   = "/buildkite-upload/"
+
+function get_download_dir_host()
+    return string(
+        "/tmp/buildkite-download/",
+        ENV["BUILDKITE_BUILD_NUMBER"], "_",
+        ENV["BUILDKITE_STEP_ID"],
+    )
+end
+
+function get_upload_dir_host()
+    return string(
+        "/tmp/buildkite-upload/",
+        ENV["BUILDKITE_BUILD_NUMBER"], "_",
+        ENV["BUILDKITE_STEP_ID"],
+    )
+end

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,8 +25,16 @@ configuration:
     gid:
       type: string
 
+    # Filenames of artifacts to download at the beginning of the job (in the `pre-command` hook)
+    artifacts_download:
+      type: array
+
+    # Filenames of artifacts to upload at the end of the job (in the `post-command` hook)
+    artifacts_upload:
+      type: array
+
     # If this is set, causes all sorts of debugging information to be printed out
     verbose:
       type: boolean
-    
+
   additionalProperties: false


### PR DESCRIPTION
As I wrote in #3, I'd prefer that the `buildkite-agent` binary not be available by default inside the sandbox.

However, this means that programs inside the sandbox won't be able to download or upload artifacts. Therefore, we need an alternative mechanism for programs inside the sandbox to download and upload artifacts.

The functionality works as follows:
1. The user specifies lists of files to be downloaded and uploaded in the `artifacts_download` and `artifacts_upload` configuration properties, respectively.
2. In the `pre-command` hook, we download each of the files listed in `artifacts_download` and save them to a location that will be mapped to the `/buildkite-download` directory inside the sandbox.
3. In the `post-command` hook, for each file listed in `artifacts_upload`, if the file exists in the `/buildkite-upload` directory inside the sandbox, we upload it.