### PR TITLE
If `verbose: true` is passed, print the Pkg manifest

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,5 +41,8 @@ BASH_TARGET="${BUILDKITE_PLUGIN_SANDBOX_SHELL:-/bin/bash}"
 julia --project="${SANDBOX_REPO}/lib" "${SANDBOX_REPO}/lib/generate_sandboxed_bash.jl" "${BASH_TARGET}"
 
 if [[ "${BUILDKITE_PLUGIN_SANDBOX_VERBOSE:-false}" == "true" ]]; then
+    echo "--- Verbose output from the Sandbox plugin"
     cat "${BASH_TARGET}"
+    julia --project="${SANDBOX_REPO}/lib" -e 'import Pkg; Pkg.status(; mode=Pkg.PKGMODE_PROJECT)'
+    julia --project="${SANDBOX_REPO}/lib" -e 'import Pkg; Pkg.status(; mode=Pkg.PKGMODE_MANIFEST)'
 fi


### PR DESCRIPTION
This will make it easier to figure out which versions of Sandbox.jl and UserNSSandbox_jll are being used in a particular run.