### PR TITLE
Turn on verbose mode by default (but allow the user to turn off verbose mode by passing the `verbose: false` plugin input)

### DIFF
--- a/lib/generate_sandboxed_bash.jl
+++ b/lib/generate_sandboxed_bash.jl
@@ -15,7 +15,7 @@ end
 
 rootfs_url = ENV["BUILDKITE_PLUGIN_SANDBOX_ROOTFS_URL"]
 rootfs_treehash = Base.SHA1(ENV["BUILDKITE_PLUGIN_SANDBOX_ROOTFS_TREEHASH"])
-verbose = parse(Bool, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_VERBOSE", "false"))
+verbose = parse(Bool, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_VERBOSE", "true"))
 workspaces = [reverse(split(pair, ":")) for pair in extract_env_array("BUILDKITE_PLUGIN_SANDBOX_WORKSPACES")]
 uid = parse(Int, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_UID", string(Sandbox.getuid())))
 gid = parse(Int, get(ENV, "BUILDKITE_PLUGIN_SANDBOX_GID", string(Sandbox.getgid())))


### PR DESCRIPTION
I personally think that the error messages are inscrutable unless you also have the verbose output.

cc: @maleadt