### PR TITLE
Use `/bin/backup/bash` instead of `/bin/truebash`

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/truebash
+#!/bin/backup/bash
 
 # Determine the persistence directory used and clear it out if it exists
 PERSIST_DIR=$(sed -n -E 's/.*--persist ([^ ]+).*/\1/p' </bin/bash 2>/dev/null)
@@ -9,4 +9,5 @@ fi
 
 # Un-do our crazy `bash` override
 echo "Removing sandbox /bin/bash overrride"
-mv /bin/truebash /bin/bash
+mv /bin/backup/bash /bin/bash
+rmdir /bin/backup || true

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -37,7 +37,8 @@ julia --project="${SANDBOX_REPO}/lib" -e "using Pkg; Pkg.instantiate()"
 # Perform absurd bash overwriting, so that all future commands are sandboxed
 echo "--- Installing bash override"
 BASH_TARGET="${BUILDKITE_PLUGIN_SANDBOX_SHELL:-/bin/bash}"
-mv -v "${BASH_TARGET}" /bin/truebash
+mkdir -p /bin/backup
+mv -v "${BASH_TARGET}" /bin/backup/bash
 
 julia --project="${SANDBOX_REPO}/lib" "${SANDBOX_REPO}/lib/generate_sandboxed_bash.jl" "${BASH_TARGET}"
 

--- a/lib/generate_sandboxed_bash.jl
+++ b/lib/generate_sandboxed_bash.jl
@@ -115,11 +115,11 @@ c = Sandbox.build_executor_command(exe, config, ``)
 # Write out `/bin/bash` wrapper script that just invokes our `sandbox` executable.
 open(ARGS[1], write=true) do io
     println(io, """
-    #!/bin/truebash
+    #!/bin/backup/bash
 
     # Don't sandbox `sandbox-buildkite-plugin` itself
     if [[ "\${BUILDKITE_PLUGIN_NAME}" == "SANDBOX" ]]; then
-        exec /bin/truebash "\$@"
+        exec /bin/backup/bash "\$@"
     fi
 
     # Ensure that PATH contains the bare minimum that any sane rootfs might need


### PR DESCRIPTION
buildkite has started trying to tell if something is a posix shell [0] or not, and they do it by inspecting the basename of the executable.  So we need to keep the basename of `bash` the same.

[0] https://github.com/buildkite/agent/blob/c7693c49ad7ac52bfaf1270dab35dfc447f23228/internal/shellscript/shellscript.go#L44-L64