### PR TITLE
Update manifests for all versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       arch: "x86_64"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1
+          version: "1"
       # Use the current directory as the plugin source, so we're testing this version of `sandbox`
       - "./.buildkite/plugins/sandbox":
           rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"
@@ -27,7 +27,7 @@ steps:
       arch: "x86_64"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.10
+          version: "1.10"
       # Use the current directory as the plugin source, so we're testing this version of `sandbox`
       - "./.buildkite/plugins/sandbox":
           rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"
@@ -48,7 +48,7 @@ steps:
       arch: "x86_64"
     plugins:
       - JuliaCI/julia#v1:
-          version: nightly
+          version: "nightly"
       # Use the current directory as the plugin source, so we're testing this version of `sandbox`
       - "./.buildkite/plugins/sandbox":
           rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"
@@ -69,7 +69,7 @@ steps:
       arch: "x86_64"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1
+          version: "1"
       # Create a file in the outside environment
       - improbable-eng/metahook:
           pre-command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ":desert: :toolbox: Basic sandboxing test"
+  - label: ":desert: :toolbox: Basic sandboxing test (Julia v1)"
     agents:
       queue: "juliaecosystem"
       sandbox_capable: "true"
@@ -7,6 +7,48 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           version: 1
+      # Use the current directory as the plugin source, so we're testing this version of `sandbox`
+      - "./.buildkite/plugins/sandbox":
+          rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"
+          rootfs_treehash: "5b44fab874ec426cad9b80b7dffd2b3f927c9e7f"
+          verbose: true
+          uid: 1000
+          gid: 1000
+    commands: |
+      set -x
+      [[ "$(grep PRETTY_NAME /etc/os-release | cut -d= -f2)" == "\"Debian GNU/Linux 10 (buster)\"" ]]
+      [[ "$(id -u)" == "1000" ]]
+      [[ "$(id -g)" == "1000" ]]
+  
+  - label: ":desert: :toolbox: Basic sandboxing test (Julia v1.10)"
+    agents:
+      queue: "juliaecosystem"
+      sandbox_capable: "true"
+      arch: "x86_64"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: 1.10
+      # Use the current directory as the plugin source, so we're testing this version of `sandbox`
+      - "./.buildkite/plugins/sandbox":
+          rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"
+          rootfs_treehash: "5b44fab874ec426cad9b80b7dffd2b3f927c9e7f"
+          verbose: true
+          uid: 1000
+          gid: 1000
+    commands: |
+      set -x
+      [[ "$(grep PRETTY_NAME /etc/os-release | cut -d= -f2)" == "\"Debian GNU/Linux 10 (buster)\"" ]]
+      [[ "$(id -u)" == "1000" ]]
+      [[ "$(id -g)" == "1000" ]]
+
+  - label: ":desert: :toolbox: Basic sandboxing test (Julia nightly)"
+    agents:
+      queue: "juliaecosystem"
+      sandbox_capable: "true"
+      arch: "x86_64"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: nightly
       # Use the current directory as the plugin source, so we're testing this version of `sandbox`
       - "./.buildkite/plugins/sandbox":
           rootfs_url: "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-927c9e7f/debian_minimal.tar.gz"

--- a/lib/Manifest-v1.11.toml
+++ b/lib/Manifest-v1.11.toml
@@ -1,6 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
+julia_version = "1.11.3"
 manifest_format = "2.0"
+project_hash = "90bc13db78ce45d3870c3ea2c8db21a8cd5585b1"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -41,9 +43,9 @@ version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -81,9 +83,9 @@ version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.18.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/lib/Manifest-v1.12.toml
+++ b/lib/Manifest-v1.12.toml
@@ -43,14 +43,14 @@ version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
 uuid = "dc6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.11.0"
+version = "1.12.0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -63,9 +63,9 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.11.1+1"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
@@ -73,14 +73,14 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.8.0+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -88,9 +88,9 @@ version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.18.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -101,18 +101,18 @@ deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2024.3.11"
+version = "2024.12.31"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.0.15+2"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -195,14 +195,14 @@ version = "2024.6.23+0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.3.1+0"
+version = "1.3.1+2"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.60.0+0"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.5.0+0"
+version = "17.5.0+2"

--- a/lib/Manifest.toml
+++ b/lib/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.4"
+julia_version = "1.10.8"
 manifest_format = "2.0"
 project_hash = "90bc13db78ce45d3870c3ea2c8db21a8cd5585b1"
 
@@ -43,9 +43,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -80,9 +80,9 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.18.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
This is especially necessary for v1.12, which has now dropped MbedTLS_jll from the stdlib set.